### PR TITLE
Include clangd extension cache in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.d
 /.vscode
 /bin
+/.cache
 compile_commands.json


### PR DESCRIPTION
This PR just adds `/.cache` to the .gitignore file. The .cache folder is generated by the [clangd VSCode extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) (which I and potentially others use).